### PR TITLE
Add database health check to resolve PostgreSQL connection error in API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,23 @@ services:
     ports:
       - "5432:5432"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   fastapi-app:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: fastapi-app
+    env_file: .env
     ports:
       - "8000:8000"
     volumes:
       - ./app:/fastapi/app
     image: fastapi-app:dev
     restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy


### PR DESCRIPTION
The fastapi-app was failing with "connection refused" because it attempted to connect to PostgreSQL before the database was ready to accept connections. Added health check to ensure PostgreSQL is fully initialized before starting the FastAPI application.